### PR TITLE
issue/83/readme-usage-typo: Fix Typo in Usage Section of the Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Regardless, a channel is returned in both cases, and that can be interacted
 with directly in the REPL, for example:
 
 ```clj
-(def result (async/<!! channel)
+(def result (async/<!! channel))
 (pprint result)
 ```
 Which should give something like:


### PR DESCRIPTION
#83 

Added trailing parenthesis to def result.