### PR TITLE
issue/85/project-mesos-image-tag: Add Docker Tag to Mesos Image Name in project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
       :cluster-type :docker
       :docker {
         :container-id-file "/tmp/meson-mesos-container-id"
-        :image-name "clojusc/mesos"
+        :image-name "clojusc/mesos:1.0.1"
         :master "localhost:5050"
         :agent "localhost:5051"
         :port-mappings "5050-5051:5050-5051"}}}


### PR DESCRIPTION
#85 
Updated the mesos image name to append the available tag from [https://hub.docker.com/r/clojusc/mesos/tags](https://hub.docker.com/r/clojusc/mesos/tags).