### PR TITLE
Issue/87/subscribe arg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services: docker
 language: clojure
 before_install:
   - docker pull clojusc/mesos:1.0.1
-  - docker run -d -p 5050:5050 clojusc/mesos
+  - docker run -d -p 5050:5050 clojusc/mesos:1.0.1
 script:
   - lein travis
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - docker run -d -p 5050:5050 clojusc/mesos
 script:
   - lein travis
+dist: trusty
 jdk:
   - oraclejdk8
   #- oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
   - docker pull clojusc/mesos:1.0.1
   - docker run -d -p 5050:5050 clojusc/mesos:1.0.1
 script:
+  - lein check-deps || true # log outdated libraries, but don't exit with error.
   - lein travis
 dist: trusty
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 services: docker
 language: clojure
 before_install:
-  - docker pull clojusc/mesos
+  - docker pull clojusc/mesos:1.0.1
   - docker run -d -p 5050:5050 clojusc/mesos
 script:
   - lein travis

--- a/project.clj
+++ b/project.clj
@@ -89,7 +89,7 @@
     "travis" [
       "do"
         ["version"]
-        ["check-deps"]
+        ; ["check-deps"] ; when a package is outdated, do stops execution.
         ["compile"]
         ["uberjar"]
         ["test" ":unit"]

--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,7 @@
       :exclusions [org.clojure/clojure]
       :plugins [
         [jonase/eastwood "0.2.4"]
-        [lein-ancient "0.6.10"]
+        [lein-ancient "0.6.15"]
         [lein-bikeshed "0.4.1"]
         [lein-kibit "0.1.5"]
         [lein-shell "0.5.0"]
@@ -58,7 +58,7 @@
       :dependencies [
         [codox-theme-rdash "0.1.2"]]
       :plugins [
-        [lein-codox "0.10.3"]
+        [lein-codox "0.10.7"]
         [lein-simpleton "1.3.0"]]
       :codox {
         :project {

--- a/src/meson/api/scheduler/core.clj
+++ b/src/meson/api/scheduler/core.clj
@@ -48,6 +48,10 @@
         (recur)))))
 
 (defn subscribe
+  "Subscribe a framework to a Mesos master scheduler.
+   Provide a framework [`args`] or a minimal default is used.
+   Provide handlers [`handler`] or defaults are used which log messages received only.
+   Provide a url to the mesos master [`mesos-master`] scheduler api or localhost is used."
   ;; XXX arity-0 is just temporary, to ease dev
   ([]
     (subscribe {:framework-info {
@@ -56,11 +60,13 @@
   ([args]
     (subscribe args scheduler-handlers/default))
   ([args handler]
+    (subscribe args handler "http://localhost:5050/api/v1/scheduler"))
+  ([args handler mesos-master]
     (log/info "args:" args)
     (let [chan (async/chan)
           data (message/create-call :subscribe args)
           prepared-data (records/prepare-data data)
-          response (httpc/post "http://localhost:5050/api/v1/scheduler"
+          response (httpc/post mesos-master
                                (assoc http/stream-options
                                       :form-params prepared-data))
           stream (:body response)]


### PR DESCRIPTION
Allow the meson.api.scheduler.core/subscribe to take an additional argument of a mesos-master in order to subscribe to remote scheduler APIs.

Closes #87