### PR TITLE
issue/89/calva-ignore: Ignore VS Code Calva directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ pom.xml.asc
 /classes/
 /target/
 /checkouts/
+/.calva/
 .lein-deps-sum
 .lein-repl-history
 .lein-plugins/


### PR DESCRIPTION
Adds /.calva/ to gitignore.

Closes #89 