### PR TITLE
Issue/7/scheduler calls

### DIFF
--- a/src/meson/client/impl/master/scheduler.clj
+++ b/src/meson/client/impl/master/scheduler.clj
@@ -1,7 +1,6 @@
 (ns meson.client.impl.master.scheduler
   (:require [clj-http.conn-mgr :as http-conn-mgr]
             [clojure.data.json :as json]
-            [clojure.string :as string]
             [clojure.tools.logging :as log]
             [meson.http.core :as http]
             [meson.util.core :as util])
@@ -63,51 +62,107 @@
 
 (defn acknowledge
   ([this payload stream-id framework-id]
-    :not-yet-implemented)
+    (acknowledge this payload stream-id framework-id http/json-content-type))
   ([this payload stream-id framework-id content-type]
-    :not-yet-implemented))
+    (call
+      this
+      :acknowledge
+      payload
+      framework-id
+      content-type
+      {:connection-manager (:conn-mgr this)
+       :headers {:mesos-stream-id stream-id}})))
 
 (defn decline
   ([this payload stream-id framework-id]
-    :not-yet-implemented)
+    (decline this payload stream-id framework-id http/json-content-type))
   ([this payload stream-id framework-id content-type]
-    :not-yet-implemented))
+    (call
+      this
+      :decline
+      payload
+      framework-id
+      content-type
+      {:connection-manager (:conn-mgr this)
+       :headers {:mesos-stream-id stream-id}})))
 
 (defn kill-task
   ([this payload stream-id framework-id]
-    :not-yet-implemented)
+    (kill-task this payload stream-id framework-id http/json-content-type))
   ([this payload stream-id framework-id content-type]
-    :not-yet-implemented))
+    (call
+      this
+      :kill
+      payload
+      framework-id
+      content-type
+      {:connection-manager (:conn-mgr this)
+       :headers {:mesos-stream-id stream-id}})))
 
 (defn message
   ([this payload stream-id framework-id]
-    :not-yet-implemented)
+    (message this payload stream-id framework-id http/json-content-type))
   ([this payload stream-id framework-id content-type]
-    :not-yet-implemented))
+    (call
+      this
+      :message
+      payload
+      framework-id
+      content-type
+      {:connection-manager (:conn-mgr this)
+       :headers {:mesos-stream-id stream-id}})))
 
 (defn reconcile
   ([this payload stream-id framework-id]
-    :not-yet-implemented)
+    (reconcile this payload stream-id framework-id http/json-content-type))
   ([this payload stream-id framework-id content-type]
-    :not-yet-implemented))
+    (call
+      this
+      :reconcile
+      payload
+      framework-id
+      content-type
+      {:connection-manager (:conn-mgr this)
+       :headers {:mesos-stream-id stream-id}})))
 
 (defn request
   ([this payload stream-id framework-id]
-    :not-yet-implemented)
+    (request this payload stream-id framework-id http/json-content-type))
   ([this payload stream-id framework-id content-type]
-    :not-yet-implemented))
+    (call
+      this
+      :request  ; type is request, json keyword is requests (plural)
+      payload
+      framework-id
+      content-type
+      {:connection-manager (:conn-mgr this)
+       :headers {:mesos-stream-id stream-id}})))
 
 (defn revive
   ([this payload stream-id framework-id]
-    :not-yet-implemented)
+    (revive this payload stream-id framework-id http/json-content-type))
   ([this payload stream-id framework-id content-type]
-    :not-yet-implemented))
+    (call
+      this
+      :revive
+      payload
+      framework-id
+      content-type
+      {:connection-manager (:conn-mgr this)
+       :headers {:mesos-stream-id stream-id}})))
 
 (defn shutdown-executor
   ([this payload stream-id framework-id]
-    :not-yet-implemented)
+    (shutdown-executor this payload stream-id framework-id http/json-content-type))
   ([this payload stream-id framework-id content-type]
-    :not-yet-implemented))
+    (call
+      this
+      :shutdown
+      payload
+      framework-id
+      content-type
+      {:connection-manager (:conn-mgr this)
+       :headers {:mesos-stream-id stream-id}})))
 
 (defn subscribe
   ([this payload]
@@ -126,10 +181,17 @@
        :connection-manager (:conn-mgr this)})))
 
 (defn teardown
-  ([this payload stream-id framework-id]
-    :not-yet-implemented)
-  ([this payload stream-id framework-id content-type]
-    :not-yet-implemented))
+  ([this stream-id framework-id]
+    (teardown this stream-id framework-id http/json-content-type))
+  ([this stream-id framework-id content-type]
+    (call
+      this
+      :teardown
+       nil
+       framework-id
+       content-type
+       {:connection-manager (:conn-mgr this)
+        :headers {:mesos-stream-id stream-id}})))
 
 (def behaviour
   {:accept accept

--- a/src/meson/client/impl/master/scheduler.clj
+++ b/src/meson/client/impl/master/scheduler.clj
@@ -30,6 +30,20 @@
   (log/debug "Stopping connection manager for the scheduler ...")
   (http-conn-mgr/shutdown-manager (:conn-mgr this)))
 
+(defn payload-kw
+  "Determine the payload's keyword.
+   Some API endpoints may break the 1 to 1 pattern of :type
+   and payload keyword."
+  [^Keyword type]
+    (condp = type
+      :request (str (util/keyword->lower type) "s")
+      (util/keyword->lower type)))
+
+(comment
+  (payload-kw :request) ; plural expected
+  (payload-kw :accept) ; singular expected
+  (payload-kw :subscribe)) ; singular expected
+
 (defn call
   ([this ^Keyword type]
     (call this type nil nil))
@@ -39,7 +53,7 @@
     (call this type payload framework-id content-type {}))
   ([this ^Keyword type payload framework-id content-type opts]
     (let [data {:type (util/keyword->upper type)
-                (util/keyword->lower type) payload}]
+                (payload-kw type) payload}]
       (http/post
         this
         scheduler-path

--- a/src/meson/client/impl/master/scheduler.clj
+++ b/src/meson/client/impl/master/scheduler.clj
@@ -30,19 +30,19 @@
   (log/debug "Stopping connection manager for the scheduler ...")
   (http-conn-mgr/shutdown-manager (:conn-mgr this)))
 
-(defn payload-kw
-  "Determine the payload's keyword.
+(defn payload-key
+  "Determine the payload's key.
    Some API endpoints may break the 1 to 1 pattern of :type
-   and payload keyword."
+   and payload key."
   [^Keyword type]
     (condp = type
       :request (str (util/keyword->lower type) "s")
       (util/keyword->lower type)))
 
 (comment
-  (payload-kw :request) ; plural expected
-  (payload-kw :accept) ; singular expected
-  (payload-kw :subscribe)) ; singular expected
+  (payload-key :request) ; plural expected
+  (payload-key :accept) ; singular expected
+  (payload-key :subscribe)) ; singular expected
 
 (defn call
   ([this ^Keyword type]
@@ -53,7 +53,7 @@
     (call this type payload framework-id content-type {}))
   ([this ^Keyword type payload framework-id content-type opts]
     (let [data {:type (util/keyword->upper type)
-                (payload-kw type) payload}]
+                (payload-key type) payload}]
       (http/post
         this
         scheduler-path


### PR DESCRIPTION
Added missing scheduler calls.
Removed un-used clojure.string require.
New helper function (payload-key) due to the ["request" Mesos http api endpoint](http://mesos.apache.org/documentation/latest/scheduler-http-api/#request) breaking the 1 to 1 pattern of type/payload key. (type: REQUEST, requests: payload)

Closes #7 