### PR TITLE
Issue/12/implement operator calls

### DIFF
--- a/src/meson/client/impl/agent/operator.clj
+++ b/src/meson/client/impl/agent/operator.clj
@@ -1,0 +1,86 @@
+(ns meson.client.impl.agent.operator
+  "v1 Operator HTTP API functions for agents."
+  (:require [clojure.data.json :as json]
+            [meson.http.core :as http]
+            [meson.util.core :as util])
+  (:import [clojure.lang Keyword]))
+
+(def operator-path "api/v1")
+
+(defn call
+  "HTTP call to the Mesos operator api."
+  ([this ^Keyword type]
+   (call this type nil))
+  ([this ^Keyword type payload]
+   (call this type payload http/json-content-type))
+  ([this ^Keyword type payload content-type]
+   (call this type payload content-type {}))
+  ([this ^Keyword type payload content-type opts]
+   (let [data {:type (util/keyword->upper type)
+               (util/keyword->lower type) payload}]
+     (http/post
+      this
+      operator-path
+      :body (json/write-str data)
+      :opts (into opts {:content-type content-type
+                        :accept content-type})))))
+
+(defn add-resource-provider-config [this payload]
+  :not-implemented)
+
+(defn attach-container-input [this payload]
+  :not-implemented)
+
+(defn attach-container-output [this payload]
+  :not-implemented)
+
+(defn get-containers
+  ([this]
+   :not-implemented)
+  ([this payload]
+   :not-implemented))
+
+(defn get-resource-providers [this]
+  :not-implemented)
+
+(defn kill-nested-containers [this payload]
+  :not-implemented)
+
+(defn launch-nested-container [this payload]
+  :not-implemented)
+
+(defn launch-nested-container-session [this payload]
+  :not-implemented)
+
+(defn prune-images
+  ([this]
+   :not-implemented)
+  ([this payload]
+   :not-implemented))
+
+(defn remove-nested-container [this payload]
+  :not-implemented)
+
+(defn remove-resource-provider-config [this payload]
+  :not-implemented)
+
+(defn update-resource-provider-config [this payload]
+  :not-implemented)
+
+(defn wait-nested-container [this payload]
+  :not-implemented)
+
+(def behaviour
+  {:add-resource-provider-config add-resource-provider-config
+   :attach-container-input attach-container-input
+   :attach-container-output attach-container-output
+   :get-containers get-containers
+   :get-resource-providers get-resource-providers
+   :kill-nested-containers kill-nested-containers
+   :launch-nested-container launch-nested-container
+   :launch-nested-container-session launch-nested-container-session
+   :prune-images prune-images
+   :remove-nested-container remove-nested-container
+   :remove-resource-provider-config remove-resource-provider-config
+   :update-resource-provider-config update-resource-provider-config
+   :wait-nested-container wait-nested-container})

--- a/src/meson/client/impl/master/operator.clj
+++ b/src/meson/client/impl/master/operator.clj
@@ -1,0 +1,117 @@
+(ns meson.client.impl.master.operator
+  "v1 Operator HTTP API functions for masters."
+  (:require [clojure.data.json :as json]
+            [meson.http.core :as http]
+            [meson.util.core :as util])
+  (:import [clojure.lang Keyword]))
+
+(def operator-path "api/v1")
+
+(defn call
+  "HTTP call to the Mesos operator api."
+  ([this ^Keyword type]
+   (call this type nil))
+  ([this ^Keyword type payload]
+   (call this type payload http/json-content-type))
+  ([this ^Keyword type payload content-type]
+   (call this type payload content-type {}))
+  ([this ^Keyword type payload content-type opts]
+   (let [data {:type (util/keyword->upper type)
+               (util/keyword->lower type) payload}]
+     (http/post
+      this
+      operator-path
+      :body (json/write-str data)
+      :opts (into opts {:content-type content-type
+                        :accept content-type})))))
+
+(defn create-volumes
+  [this payload]
+  :not-implemented)
+
+(defn deactivate-agent [this payload]
+  :not-implemented)
+
+(defn destroy-volumes [this payload]
+  :not-implemented)
+
+(defn drain-agent [this payload]
+  :not-implemented)
+
+(defn get-agents [this]
+  :not-implemented)
+
+(defn get-maintenance-schedule [this]
+  :not-implemented)
+
+(defn get-maintenance-status [this]
+  :not-implemented)
+
+(defn get-master [this]
+  :not-implemented)
+
+(defn get-quota [this]
+  :not-implemented)
+
+(defn get-roles [this]
+  :not-implemented)
+
+(defn get-weights [this]
+  :not-implemented)
+
+(defn grow-volume [this payload]
+  :not-implemented)
+
+(defn mark-agent-gone [this payload]
+  :not-implemented)
+
+(defn reactivate-agent [this payload]
+  :not-implemented)
+
+(defn reserve-resources [this payload]
+  :not-implemented)
+
+(defn shrink-volume [this payload]
+  :not-implemented)
+
+(defn start-maintenance [this payload]
+  :not-implemented)
+
+(defn stop-maintenance [this payload]
+  :not-implemented)
+
+(defn unreserve-resources [this payload]
+  :not-implemented)
+
+(defn update-maintenance-schedule [this payload]
+  :not-implemented)
+
+(defn update-quota [this payload]
+  :not-implemented)
+
+(defn update-weights [this payload]
+  :not-implemented)
+
+(def behaviour
+  {:create-volumes create-volumes
+   :deactivate-agent deactivate-agent
+   :destroy-volumes destroy-volumes
+   :drain-agent drain-agent
+   :get-agents get-agents
+   :get-maintenance-schedule get-maintenance-schedule
+   :get-maintenance-status get-maintenance-status
+   :get-master get-master
+   :get-quota get-quota
+   :get-roles get-roles
+   :get-weights get-weights
+   :grow-volume grow-volume
+   :mark-agent-gone mark-agent-gone
+   :reactivate-agent reactivate-agent
+   :reserve-resources reserve-resources
+   :shrink-volume shrink-volume
+   :start-maintenance start-maintenance
+   :stop-maintenance stop-maintenance
+   :unreserve-resources unreserve-resources
+   :update-maintenance-schedule update-maintenance-schedule
+   :update-quota update-quota
+   :update-weights update-weights})

--- a/src/meson/client/impl/operator.clj
+++ b/src/meson/client/impl/operator.clj
@@ -1,0 +1,117 @@
+(ns meson.client.impl.operator
+  "v1 Operator HTTP API functions common to masters and agents."
+  (:require [clojure.data.json :as json]
+            [meson.http.core :as http]
+            [meson.util.core :as util])
+  (:import [clojure.lang Keyword]))
+
+(def operator-path "api/v1")
+
+(defn call
+  "HTTP call to the Mesos operator api."
+  ([this ^Keyword type]
+   (call this type nil))
+  ([this ^Keyword type payload]
+   (call this type payload http/json-content-type))
+  ([this ^Keyword type payload content-type]
+   (call this type payload content-type {}))
+  ([this ^Keyword type payload content-type opts]
+   (let [data {:type (util/keyword->upper type)
+               (util/keyword->lower type) payload}]
+     (http/post
+      this
+      operator-path
+      :body (json/write-str data)
+      :opts (into opts {:content-type content-type
+                        :accept content-type})))))
+
+(defn get-executors
+  "Queries about all the executors known to the master/agent."
+  [this]
+  (call this :get-executors))
+
+(defn get-flags
+  "Retrieve the master/agent overall flag configuration."
+  [this]
+  (call this :get-flags))
+
+(defn get-frameworks
+  "Retrieve information about all the frameworks known to the master/agent."
+  [this]
+  (call this :get-frameworks))
+
+(defn get-health
+  "Retrieve health status of the master/agent."
+  [this]
+  (call this :get-health))
+
+(defn get-logging-level
+  "Retrieve the master/agent logging level."
+  [this]
+  (call this :get-logging-level))
+
+(defn get-metrics
+  "Snapshot of the current metrics. If the optional `timeout` is set in the call,
+   it will be used to determine the maximum amount of time the API will take to respond.
+   Some metrics may not be included if the timeout is exceeded."
+  ([this]
+   (call this :get-metrics))
+  ([this payload]
+   (call this :get-metrics payload)))
+
+(defn get-operations
+  "List of all offer operations throughout the cluster (master API) or known to the
+   agent (agent API). Does not including LAUNCH or LAUNCH_GROUP, which can be retrieved
+   with get-tasks."
+  [this]
+  (call this :get-operations))
+
+(defn get-state
+  "Retrieve overall cluster state (master API) or full state of the agent (agent API)."
+  [this]
+  (call this :get-state))
+
+(defn get-tasks
+  "All tasks known to the master or agent."
+  [this]
+  (call this :get-tasks))
+
+(defn get-version
+  "Retrieve master/agent version information."
+  [this]
+  (call this :get-version))
+
+(defn list-files
+  "Retrieve file listing for a directory `path` in the master/agent."
+  [this payload]
+  (call this :list-files payload))
+
+(defn read-file
+  "Reads data from a file on the master/agent. This call takes the `path` of the
+   file to be read, the `offset` to start reading, and the maximum number of
+   bytes to read (`length`)."
+  [this payload]
+  (call this :read-file payload))
+
+(defn set-logging-level
+  "Sets logging verbosity `level` for a specified `duration`. Mesos uses glog for logging.
+   (https://github.com/google/glog)
+   The library only uses verbose logging which means nothing will be output unless the
+   verbosity level is set (by default it's 0, libprocess uses levels 1,2, and 3)."
+  [this payload]
+  (call this :set-logging-level payload))
+
+(def behaviour
+  {:get-executors get-executors
+   :get-flags get-flags
+   :get-frameworks get-frameworks
+   :get-health get-health
+   :get-logging-level get-logging-level
+   :get-metrics get-metrics
+   :get-operations get-operations
+   :get-state get-state
+   :get-tasks get-tasks
+   :get-version get-version
+   :list-files list-files
+   :read-file read-file
+   :set-logging-level set-logging-level})

--- a/src/meson/protocols/agent/operator.clj
+++ b/src/meson/protocols/agent/operator.clj
@@ -1,0 +1,69 @@
+(ns meson.protocols.agent.operator
+  "Mesos HTTP v1 Operator API endpoints for agents.
+
+  v1 Operator master endpoints:
+  https://mesos.apache.org/documentation/latest/operator-http-api/#agent-api"
+
+  (:refer-clojure :exclude [read]))
+
+(defprotocol IAgentOperator
+  "v1 Operator Interface endpoints for agents.
+   
+   See:
+   * https://mesos.apache.org/documentation/latest/operator-http-api/#agent-api"
+
+  (add-resource-provider-config [this payload]
+    "This call launches a Local Resource Provider on the agent with the specified ResourceProviderInfo.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#add_resource_provider_config")
+
+  (attach-container-input [this payload]
+    "This call attaches to the STDIN of the primary process of a container and streams input to it.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#attach_container_input")
+
+  (attach-container-output [this payload]
+    "This call attaches to the STDOUT and STDERR of the primary process of a container and streams
+     its output back to the client.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#attach_container_output")
+
+  (get-containers [this] [this payload]
+    "This call retrieves information about containers running on this agent.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_containers")
+
+  (get-resource-providers [this]
+    "This call retrieves information about all the resource providers known to the agent.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_resource_providers")
+
+  (kill-nested-containers [this payload]
+    "This call initiates the destruction of a nested container.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#kill_nested_container")
+
+  (launch-nested-container [this payload]
+    "This call launches a nested container.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#launch_nested_container")
+
+  (launch-nested-container-session [this payload]
+    "This call launches a nested container whose lifetime is tied to the lifetime of the HTTP
+     call establishing this connection.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#launch_nested_container_session")
+
+  (prune-images [this] [this payload]
+    "This call triggers garbage collection for container images.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#prune_images")
+
+  (remove-nested-container [this payload]
+    "This call triggers the removal of a nested container and its artifacts
+     (e.g., the sandbox and runtime directories).
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#remove_nested_container")
+
+  (remove-resource-provider-config [this payload]
+    "This call terminates a given Local Resource Provider on the agent and prevents it from
+     being launched again until the config is added back.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#remove_resource_provider_config")
+
+  (update-resource-provider-config [this payload]
+    "This call updates a Local Resource Provider on the agent with the specified ResourceProviderInfo.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#update_resource_provider_config")
+
+  (wait-nested-container [this payload]
+    "This call waits for a nested container to terminate or exit.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#wait_nested_container"))

--- a/src/meson/protocols/master/operator.clj
+++ b/src/meson/protocols/master/operator.clj
@@ -1,0 +1,106 @@
+(ns meson.protocols.master.operator
+  "Mesos HTTP v1 Operator API endpoints for masters.
+
+  v1 Operator master endpoints:
+  https://mesos.apache.org/documentation/latest/operator-http-api/#master-api"
+
+  (:refer-clojure :exclude [read]))
+
+(defprotocol IMasterOperator
+  "v1 Operator Interface endpoints for masters.
+   
+   See:
+   * https://mesos.apache.org/documentation/latest/operator-http-api/#master-api"
+
+  (create-volumes [this payload]
+    "This call create persistent volumes on reserved resources.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#create_volumes")
+
+  (deactivate-agent [this payload]
+    "Deactivates the specified agent, preventing offers for that agent’s resources from being sent to schedulers until the agent is reactivated.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#deactivate_agent")
+
+  (destroy-volumes [this payload]
+    "This call destroys persistent volumes.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#destroy_volumes")
+
+  (drain-agent [this payload]
+    "Initiates draining on the specified agent.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#drain_agent")
+
+  (get-agents [this]
+    "This call retrieves information about all the agents known to the master.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#get_agents")
+
+  (get-maintenance-schedule [this]
+    "This call retrieves the cluster’s maintenance schedule.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#get_maintenance_schedule")
+
+  (get-maintenance-status [this]
+    "This call retrieves the cluster’s maintenance status.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#get_maintenance_status")
+
+  (get-master [this]
+    "This call retrieves information about the master.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#get_master")
+
+  (get-quota [this]
+    "This call retrieves the cluster’s configured quotas.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#get_quota")
+
+  (get-roles [this]
+    "Query the information about roles.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#get_roles")
+
+  (get-weights [this]
+    "This call retrieves the information about role weights.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#get_weights")
+
+  (grow-volume [this payload]
+    "This call grows the size of a persistent volume.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#grow_volume")
+
+  (mark-agent-gone [this payload]
+    "This call can be used by operators to assert that an agent instance has failed
+     and is never coming back (e.g., ephemeral instance from cloud provider).
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#mark_agent_gone")
+
+  (reactivate-agent [this payload]
+    "Reactivates the specified agent, resuming offers for that agent’s resources
+     if the agent was previously deactivated.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#reactivate_agent")
+
+  (reserve-resources [this payload]
+    "This call is used to update resource reservations.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#reserve_resources")
+
+  (shrink-volume [this payload]
+    "This call shrinks the size of a persistent volume.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#shrink_volume")
+
+  (start-maintenance [this payload]
+    "This call starts the maintenance of the cluster, this would bring a set of machines down.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#start_maintenance")
+
+  (stop-maintenance [this payload]
+    "Stops the maintenance of the cluster, this would bring a set of machines back up.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#stop_maintenance")
+
+  (unreserve-resources [this payload]
+    "This call unreserve resources dynamically on a specific agent.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#unreserve_resources")
+
+  (update-maintenance-schedule [this payload]
+    "This call updates the cluster’s maintenance schedule.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#update_maintenance_schedule")
+
+  (update-quota [this payload]
+    "This call updates the quota for the specified role(s). These configurations are
+     applied in an all-or-nothing manner. To reset a role’s quota back to the default
+     (no guarantees and no limits), simply update its quota with empty guarantees and
+     limits fields.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#update_quota")
+
+  (update-weights [this payload]
+    "This call updates weights for specific role.
+    * http://mesos.apache.org/documentation/latest/operator-http-api/#update_weights"))

--- a/src/meson/protocols/operator.clj
+++ b/src/meson/protocols/operator.clj
@@ -1,0 +1,87 @@
+(ns meson.protocols.operator
+  "Mesos HTTP v1 Operator API endpoints that are common to masters and agents.
+
+  v1 Operator endpoints: https://mesos.apache.org/documentation/latest/operator-http-api/"
+
+  (:refer-clojure :exclude [read]))
+
+(defprotocol IOperator
+  "v1 Operator Interface endpoints common to masters and agents.
+   
+   See:
+   * https://mesos.apache.org/documentation/latest/operator-http-api/#master-api
+   * https://mesos.apache.org/documentation/latest/operator-http-api/#agent-api"
+
+  (get-executors [this]
+    "Queries about all the executors known to the master/agent.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_executors
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_executors-1")
+
+  (get-flags [this]
+    "Retrieve the master/agent overall flag configuration.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_flags
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_flags-1")
+
+  (get-frameworks [this]
+    "Retrieve information about all the frameworks known to the master/agent.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_frameworks
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_frameworks-1")
+
+  (get-health [this]
+    "Retrieve health status of the master/agent.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_health
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_health-1")
+
+  (get-logging-level [this]
+    "Retrieve the master/agent logging level.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_logging_level
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_logging_level-1")
+
+  (get-metrics [this] [this payload]
+    "Snapshot of the current metrics. If the optional `timeout` is set in the call,
+     it will be used to determine the maximum amount of time the API will take to respond.
+     Some metrics may not be included if the timeout is exceeded.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_metrics
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_metrics-1")
+
+  (get-operations [this]
+    "List of all offer operations throughout the cluster (master API) or known to the
+     agent (agent API). Does not including LAUNCH or LAUNCH_GROUP, which can be retrieved
+     with get-tasks.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_operations
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_operations-1")
+
+  (get-state [this]
+    "Retrieve overall cluster state (master API) or full state of the agent (agent API).
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_state
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_state-1")
+
+  (get-tasks [this]
+    "All tasks known to the master or agent.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_tasks
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_tasks-1")
+
+  (get-version [this]
+    "Retrieve master/agent version information.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_version
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#get_version-1")
+
+  (list-files [this payload]
+    "Retrieve file listing for a directory `path` in the master/agent.
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#list_files
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#list_files-1")
+
+  (read-file [this payload]
+    "Reads data from a file on the master/agent. This call takes the `path` of the
+     file to be read, the `offset` to start reading, and the maximum number of
+     bytes to read (`length`).
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#read_file
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#read_file-1")
+
+  (set-logging-level [this payload]
+    "Sets logging verbosity `level` for a specified `duration`. Mesos uses glog for logging.
+     (https://github.com/google/glog)
+     The library only uses verbose logging which means nothing will be output unless the
+     verbosity level is set (by default it's 0, libprocess uses levels 1,2, and 3).
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#set_logging_level
+    * https://mesos.apache.org/documentation/latest/operator-http-api/#set_logging_level-1"))


### PR DESCRIPTION
Added [v1 operator http api support](https://mesos.apache.org/documentation/latest/operator-http-api/):

- Protocols for v1 operator (common, agent only, master only)
- Protocols implementation
  - Implementation for common between agent/master calls
  - Scaffolding for agent and master specific calls. (will be implemented via #59 and #58)

Will integrate into agent/master clients and remove un-versioned API protocols/implementation in separate issues/pull requests.

From: https://mesos.apache.org/documentation/latest/endpoints/

"NOTE: If you are using Mesos 1.1 or later, we recommend using the new v1 Operator HTTP API instead of the unversioned REST endpoints listed below. These endpoints will be deprecated in the future."

Closes #12 