### PR TITLE
issue/99/dev-mesos-version: Update Meson Dev Mesos to a newer version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,11 +22,12 @@
       :cluster-deployment :local
       :cluster-type :docker
       :docker {
-        :container-id-file "/tmp/meson-mesos-container-id"
-        :image-name "clojusc/mesos:1.0.1"
+        :container-name "meson-mesos"
+        :image-name "mesos/mesos-mini:1.9.x"
         :master "localhost:5050"
         :agent "localhost:5051"
-        :port-mappings "5050-5051:5050-5051"}}}
+        :mesos-ports "5050-5051:5050-5051"
+        :marathon-ports "8080:8080"}}}
   :profiles {
     :uberjar {
       :aot :all}

--- a/src/meson/config.clj
+++ b/src/meson/config.clj
@@ -1,6 +1,5 @@
 (ns meson.config
-  (:require [leiningen.core.project :as project]
-            [taoensso.timbre :as log])
+  (:require [leiningen.core.project :as project])
   (:refer-clojure :exclude [name]))
 
 (def all (project/read))
@@ -23,11 +22,13 @@
 
 (def docker (:docker mesos))
 
-(def docker-container-id-file (:container-id-file docker))
+(def docker-container-name (:container-name docker))
 
 (def docker-image-name (:image-name docker))
 
-(def docker-port-mappings (:port-mappings docker))
+(def docker-mesos-ports (:mesos-ports docker))
+
+(def docker-marathon-ports (:marathon-ports docker))
 
 (def docker-agent (:agent docker))
 


### PR DESCRIPTION
Changed project's development mesos version to mesos-mini. (https://mesos.apache.org/blog/mesos-mini/)

This is similar to minikube (self-contained cluster), but the Mesos version.

Mesos-mini (1.9.x) is more up to date/actively maintained than the mesosphere/mesos official images (1.7.1).

Closes #99 